### PR TITLE
Setlist.fm: move source of truth to KV + scheduled runtime refresh

### DIFF
--- a/src/lib/setlistfm/concerts-data.ts
+++ b/src/lib/setlistfm/concerts-data.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
+import { Result } from "better-result";
 
 import concertsJson from "../../../content/concerts.json";
 import { hashString } from "@/lib/hash";
+import { getJson } from "@/lib/store";
 
 import type { Setlist } from "./schema";
 
@@ -12,6 +14,7 @@ import type { Setlist } from "./schema";
  * changes — not on a TTL.
  */
 export const CONCERTS_DATA_FINGERPRINT = hashString(JSON.stringify(concertsJson));
+export const SETLIST_FM_CONCERTS_KV_KEY = "setlistfm:concerts:raw:v1";
 
 const SongSchema = z.union([
 	z.string(),
@@ -37,6 +40,7 @@ const ConcertsFileSchema = z.object({
 });
 
 export type ConcertEntry = z.infer<typeof ConcertEntrySchema>;
+export type ConcertsFile = z.infer<typeof ConcertsFileSchema>;
 
 const isoDateToSetlistFm = (iso: string): string => {
 	const [y, m, d] = iso.split("-");
@@ -74,3 +78,37 @@ export const loadConcerts = (): ReadonlyArray<Setlist> => {
 	const parsed = ConcertsFileSchema.parse(concertsJson);
 	return parsed.concerts.map(entryToSetlist);
 };
+
+const loadConcertEntriesFromFile = (): ConcertsFile => {
+	return ConcertsFileSchema.parse(concertsJson);
+};
+
+export const loadConcertEntries = async (): Promise<{
+	entries: ConcertsFile["concerts"];
+	source: "kv" | "file";
+}> => {
+	const fromKv = await getJson<ConcertsFile>({ key: SETLIST_FM_CONCERTS_KV_KEY });
+	if (Result.isOk(fromKv) && fromKv.value) {
+		const parsed = ConcertsFileSchema.safeParse(fromKv.value);
+		if (parsed.success) return { entries: parsed.data.concerts, source: "kv" };
+		console.error("[setlistfm] invalid KV concerts payload; falling back to file", {
+			issues: parsed.error.issues,
+		});
+	}
+
+	const parsed = loadConcertEntriesFromFile();
+	return { entries: parsed.concerts, source: "file" };
+};
+
+export const loadConcertsWithSource = async (): Promise<{
+	setlists: ReadonlyArray<Setlist>;
+	source: "kv" | "file";
+}> => {
+	const data = await loadConcertEntries();
+	return {
+		setlists: data.entries.map(entryToSetlist),
+		source: data.source,
+	};
+};
+
+export { ConcertEntrySchema, ConcertsFileSchema };

--- a/src/lib/setlistfm/scrape.ts
+++ b/src/lib/setlistfm/scrape.ts
@@ -1,0 +1,326 @@
+import { Result, TaggedError } from "better-result";
+
+import type { ConcertEntry } from "./concerts-data";
+
+const SETLIST_FM_BASE_URL = "https://www.setlist.fm";
+const SETLIST_FM_USER_DEFAULT = "kpmdev";
+const REQUEST_DELAY_MS = 350;
+const MAX_PAGES = 25;
+const USER_AGENT =
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36";
+
+const MONTHS: Record<string, number> = {
+	Jan: 1,
+	Feb: 2,
+	Mar: 3,
+	Apr: 4,
+	May: 5,
+	Jun: 6,
+	Jul: 7,
+	Aug: 8,
+	Sep: 9,
+	Oct: 10,
+	Nov: 11,
+	Dec: 12,
+};
+
+class SetlistScrapeError extends TaggedError("SetlistScrapeError")<{
+	readonly url?: string;
+	readonly error: unknown;
+}>() {}
+
+const sleep = (ms: number): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, ms));
+
+const decodeHtml = (value: string): string =>
+	value
+		.replace(/&amp;/g, "&")
+		.replace(/&lt;/g, "<")
+		.replace(/&gt;/g, ">")
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.replace(/&apos;/g, "'")
+		.replace(/&nbsp;/g, " ");
+
+const slugFromUrl = (url: string): string => {
+	const match = url.match(/\/setlist\/[^/]+\/\d+\/([^"/]+)\.html/);
+	if (match?.[1]) return match[1];
+	return url.split("/").pop()?.replace(/\.html$/, "") ?? url;
+};
+
+const extractSetlistLinks = (html: string): string[] => {
+	const links = new Set<string>();
+	const r1 = /href="\.\.\/setlist\/([^"]+\.html)"/g;
+	const r2 = /href="setlist\/([^"]+\.html)"/g;
+	let match: RegExpExecArray | null = null;
+	while ((match = r1.exec(html)) !== null) {
+		if (match[1]) links.add(`${SETLIST_FM_BASE_URL}/setlist/${match[1]}`);
+	}
+	while ((match = r2.exec(html)) !== null) {
+		if (match[1]) links.add(`${SETLIST_FM_BASE_URL}/setlist/${match[1]}`);
+	}
+	return [...links];
+};
+
+const extractPageNavLinks = (html: string): string[] => {
+	const regex =
+		/href="(?:\.\.\/)?\?(wicket:interface=:[^"]+:navigation:\d+:pageLink::ILinkListener::)"/g;
+	const links = new Set<string>();
+	let match: RegExpExecArray | null = null;
+	while ((match = regex.exec(html)) !== null) {
+		if (match[1]) links.add(match[1].replace(/&amp;/g, "&"));
+	}
+	return [...links];
+};
+
+const extractNextLink = (html: string): string | null => {
+	const match = html.match(
+		/href="(?:\.\.\/)?\?(wicket:interface=:[^"]+:next::ILinkListener::)"/,
+	);
+	return match?.[1] ? match[1].replace(/&amp;/g, "&") : null;
+};
+
+const parseSetlistPage = (html: string, url: string): ConcertEntry | null => {
+	const monthMatch = html.match(/<span class="month">([^<]+)<\/span>/);
+	const dayMatch = html.match(/<span class="day">([^<]+)<\/span>/);
+	const yearMatch = html.match(/<span class="year">([^<]+)<\/span>/);
+	if (!monthMatch?.[1] || !dayMatch?.[1] || !yearMatch?.[1]) return null;
+
+	const month = MONTHS[monthMatch[1].trim()];
+	const day = Number.parseInt(dayMatch[1].trim(), 10);
+	const year = Number.parseInt(yearMatch[1].trim(), 10);
+	if (!month || !Number.isFinite(day) || !Number.isFinite(year)) return null;
+
+	const date = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+	const ogTitleMatch = html.match(
+		/<meta property="og:title" content="([^"]+) Setlist at [^"]+"/,
+	);
+	const artist = ogTitleMatch?.[1] ? decodeHtml(ogTitleMatch[1]).trim() : "";
+	if (!artist) return null;
+
+	let venue = "";
+	let cityRaw = "";
+	const venueHeaderMatch = html.match(
+		/<div class="venueHeader">[\s\S]*?<h2>([^<]+)<\/h2>[\s\S]*?<span><span>([^<]+)<\/span>/,
+	);
+	if (venueHeaderMatch?.[1] && venueHeaderMatch[2]) {
+		venue = decodeHtml(venueHeaderMatch[1]).trim();
+		cityRaw = decodeHtml(venueHeaderMatch[2]).trim();
+	} else {
+		const inlineVenueMatch = html.match(
+			/<div class="setlistHeadline">[\s\S]*?<span>at <a[^>]*title="More setlists from ([^"]+)"/,
+		);
+		if (inlineVenueMatch?.[1]) {
+			const full = decodeHtml(inlineVenueMatch[1]).trim();
+			const parts = full.split(",").map((part) => part.trim());
+			venue = parts[0] ?? "";
+			cityRaw = parts.slice(1).join(", ");
+		}
+	}
+
+	const cityParts = cityRaw
+		.split(",")
+		.map((part) => part.trim())
+		.filter(Boolean);
+	const city = cityParts.slice(0, Math.min(2, cityParts.length)).join(", ");
+
+	const tourMatch = html.match(
+		/<span>Tour:<\/span>\s*<span><a[^>]*><span>([^<]+)<\/span>/,
+	);
+	const tour = tourMatch?.[1] ? decodeHtml(tourMatch[1]).trim() : null;
+
+	const songs: Array<string | { name: string; cover: string }> = [];
+	const songRegex =
+		/<li class="setlistParts song">([\s\S]*?)(?=<li class="setlistParts|<\/ol>)/g;
+	let songMatch: RegExpExecArray | null = null;
+	while ((songMatch = songRegex.exec(html)) !== null) {
+		const songBlock = songMatch[1] ?? "";
+		const labelMatch = songBlock.match(
+			/<a class="songLabel"[^>]*title="Statistics for ([^"]+) performed by [^"]+"/,
+		);
+		const fallbackLabel = songBlock.match(/<a class="songLabel"[^>]*>([^<]+)</);
+		const songName = labelMatch?.[1]
+			? decodeHtml(labelMatch[1]).trim()
+			: fallbackLabel?.[1]
+				? decodeHtml(fallbackLabel[1]).trim()
+				: "";
+		if (!songName) continue;
+		const coverMatch = songBlock.match(
+			/<a[^>]+title="More songs[^"]*by ([^"]+)"[^>]*>[^<]+<\/a>\s*cover/i,
+		);
+		const cover = coverMatch?.[1] ? decodeHtml(coverMatch[1]).trim() : null;
+		songs.push(cover ? { name: songName, cover } : songName);
+	}
+
+	const entry: ConcertEntry = {
+		id: slugFromUrl(url),
+		date,
+		artist,
+		venue,
+		city,
+		url,
+		songs,
+	};
+	if (tour) entry.tour = tour;
+	return entry;
+};
+
+const fetchHtmlWithSession = async (params: {
+	url: string;
+	cookieJar: string;
+	referer?: string;
+}): Promise<Result<{ html: string; cookieJar: string }, SetlistScrapeError>> => {
+	try {
+		const response = await fetch(params.url, {
+			headers: {
+				"User-Agent": USER_AGENT,
+				...(params.cookieJar ? { Cookie: params.cookieJar } : {}),
+				...(params.referer ? { Referer: params.referer } : {}),
+			},
+			redirect: "follow",
+		});
+		if (!response.ok) {
+			return Result.err(
+				new SetlistScrapeError({
+					url: params.url,
+					error: new Error(`HTTP ${response.status}`),
+				}),
+			);
+		}
+		const setCookie = response.headers.get("set-cookie");
+		const sessionMatch = setCookie?.match(/JSESSIONID=[^;]+/);
+		return Result.ok({
+			html: await response.text(),
+			cookieJar: sessionMatch?.[0] ?? params.cookieJar,
+		});
+	} catch (error) {
+		return Result.err(new SetlistScrapeError({ url: params.url, error }));
+	}
+};
+
+const collectAllSetlistLinks = async (
+	user: string,
+): Promise<Result<string[], SetlistScrapeError>> => {
+	const indexUrl = `${SETLIST_FM_BASE_URL}/attended/${user}`;
+	const first = await fetchHtmlWithSession({ url: indexUrl, cookieJar: "" });
+	if (Result.isError(first)) return first;
+
+	const all = new Set(extractSetlistLinks(first.value.html));
+	const visitedQueries = new Set<string>();
+	const queue = [...new Set(extractPageNavLinks(first.value.html))];
+	const nextFromFirst = extractNextLink(first.value.html);
+	if (nextFromFirst) queue.push(nextFromFirst);
+
+	let cookieJar = first.value.cookieJar;
+	let pageIndex = 1;
+
+	while (queue.length > 0 && pageIndex < MAX_PAGES) {
+		const query = queue.shift();
+		if (!query || visitedQueries.has(query)) continue;
+		visitedQueries.add(query);
+		pageIndex += 1;
+
+		const url = `${SETLIST_FM_BASE_URL}/?${query}`;
+		const page = await fetchHtmlWithSession({
+			url,
+			referer: indexUrl,
+			cookieJar,
+		});
+		if (Result.isError(page)) {
+			console.error("[setlistfm] failed to load pagination page", {
+				url,
+				error: page.error,
+			});
+			await sleep(REQUEST_DELAY_MS);
+			continue;
+		}
+
+		cookieJar = page.value.cookieJar;
+		for (const link of extractSetlistLinks(page.value.html)) all.add(link);
+		for (const newQuery of extractPageNavLinks(page.value.html)) {
+			if (!visitedQueries.has(newQuery) && !queue.includes(newQuery)) {
+				queue.push(newQuery);
+			}
+		}
+		const nextQuery = extractNextLink(page.value.html);
+		if (
+			nextQuery &&
+			!visitedQueries.has(nextQuery) &&
+			!queue.includes(nextQuery)
+		) {
+			queue.push(nextQuery);
+		}
+		await sleep(REQUEST_DELAY_MS);
+	}
+
+	return Result.ok([...all]);
+};
+
+const fetchSetlistEntry = async (
+	url: string,
+): Promise<Result<ConcertEntry | null, SetlistScrapeError>> => {
+	const page = await fetchHtmlWithSession({ url, cookieJar: "" });
+	if (Result.isError(page)) return page;
+	return Result.ok(parseSetlistPage(page.value.html, url));
+};
+
+const mergeConcertEntries = (
+	existing: ReadonlyArray<ConcertEntry>,
+	incoming: ReadonlyArray<ConcertEntry>,
+): ConcertEntry[] => {
+	const byId = new Map<string, ConcertEntry>();
+	for (const entry of existing) byId.set(entry.id, entry);
+	for (const entry of incoming) byId.set(entry.id, entry);
+	return [...byId.values()].sort((a, b) => b.date.localeCompare(a.date));
+};
+
+const scrapeConcertEntriesDiff = async (params?: {
+	user?: string;
+	existing?: ReadonlyArray<ConcertEntry>;
+}): Promise<
+	Result<
+		{
+			concerts: ConcertEntry[];
+			added: number;
+			discoveredLinks: number;
+		},
+		SetlistScrapeError
+	>
+> => {
+	const user = params?.user?.trim() || SETLIST_FM_USER_DEFAULT;
+	const existing = params?.existing ?? [];
+	const existingIds = new Set(existing.map((entry) => entry.id));
+
+	const linksResult = await collectAllSetlistLinks(user);
+	if (Result.isError(linksResult)) return linksResult;
+	const links = linksResult.value;
+	const newLinks = links.filter((url) => !existingIds.has(slugFromUrl(url)));
+	if (newLinks.length === 0) {
+		return Result.ok({
+			concerts: [...existing].sort((a, b) => b.date.localeCompare(a.date)),
+			added: 0,
+			discoveredLinks: links.length,
+		});
+	}
+
+	const incoming: ConcertEntry[] = [];
+	for (const url of newLinks) {
+		const entry = await fetchSetlistEntry(url);
+		if (Result.isError(entry)) {
+			console.error("[setlistfm] failed to fetch setlist", { url, error: entry.error });
+			await sleep(REQUEST_DELAY_MS);
+			continue;
+		}
+		if (entry.value) incoming.push(entry.value);
+		await sleep(REQUEST_DELAY_MS);
+	}
+
+	return Result.ok({
+		concerts: mergeConcertEntries(existing, incoming),
+		added: incoming.length,
+		discoveredLinks: links.length,
+	});
+};
+
+export { scrapeConcertEntriesDiff };
+export type { SetlistScrapeError };

--- a/src/lib/setlistfm/setlistfm.ts
+++ b/src/lib/setlistfm/setlistfm.ts
@@ -6,10 +6,17 @@ import {
 	buildSimilarTagMap,
 	buildTopGenresFromWeights,
 } from "@/lib/lastfm/genres";
-import { getOrComputeJson } from "@/lib/store";
+import { getOrComputeJson, refreshJson } from "@/lib/store";
 
-import { CONCERTS_DATA_FINGERPRINT, loadConcerts } from "./concerts-data";
+import {
+	CONCERTS_DATA_FINGERPRINT,
+	loadConcertEntries,
+	loadConcertsWithSource,
+	SETLIST_FM_CONCERTS_KV_KEY,
+	type ConcertsFile,
+} from "./concerts-data";
 import type { ConcertsData, Setlist, SetlistArtist } from "./schema";
+import { scrapeConcertEntriesDiff } from "./scrape";
 
 class SetlistFmDataError extends TaggedError("SetlistFmDataError")<{
 	readonly error: unknown;
@@ -26,8 +33,9 @@ const GENRE_COUNT = 6;
 // the ~80 Last.fm tag lookups for the genre radar) exactly when content/
 // concerts.json changes, not on a TTL. The TTL stays long as a backstop in
 // case Last.fm tag data drifts; the fingerprint handles content changes.
-export const SETLIST_FM_CACHE_KEY = `setlistfm:attended:v2:${CONCERTS_DATA_FINGERPRINT}`;
+export const SETLIST_FM_CACHE_KEY = `setlistfm:attended:v3:${CONCERTS_DATA_FINGERPRINT}`;
 const CACHE_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
+const RAW_CONCERTS_TTL_SECONDS = 365 * 24 * 60 * 60; // 1 year
 
 /**
  * Setlist.fm dates are dd-MM-yyyy. Returns null when malformed.
@@ -464,8 +472,54 @@ const buildConcertsData = async (
 const computeAttendedConcerts = async (): Promise<
 	Result<ConcertsData, SetlistFmDataError>
 > => {
-	const setlists = loadConcerts();
+	const { setlists, source } = await loadConcertsWithSource();
+	if (source === "file") {
+		console.warn("[setlistfm] using bundled concerts.json fallback");
+	}
 	return Result.ok(await buildConcertsData(setlists));
+};
+
+const refreshConcertsFromSetlistProfile = async (params?: {
+	user?: string;
+}): Promise<
+	Result<
+		{
+			totalConcerts: number;
+			addedConcerts: number;
+			discoveredLinks: number;
+		},
+		SetlistFmDataError
+	>
+> => {
+	const existing = await loadConcertEntries();
+	const scrapeResult = await scrapeConcertEntriesDiff({
+		...(params?.user ? { user: params.user } : {}),
+		existing: existing.entries,
+	});
+	if (Result.isError(scrapeResult)) {
+		return Result.err(new SetlistFmDataError({ error: scrapeResult.error }));
+	}
+
+	const rawPayload: ConcertsFile = { concerts: scrapeResult.value.concerts };
+	const rawWrite = await refreshJson<ConcertsFile, SetlistFmDataError>({
+		key: SETLIST_FM_CONCERTS_KV_KEY,
+		ttlSeconds: RAW_CONCERTS_TTL_SECONDS,
+		compute: async () => Result.ok(rawPayload),
+	});
+	if (Result.isError(rawWrite)) return rawWrite;
+
+	const aggregateWrite = await refreshJson<ConcertsData, SetlistFmDataError>({
+		key: SETLIST_FM_CACHE_KEY,
+		ttlSeconds: CACHE_TTL_SECONDS,
+		compute: computeAttendedConcerts,
+	});
+	if (Result.isError(aggregateWrite)) return aggregateWrite;
+
+	return Result.ok({
+		totalConcerts: scrapeResult.value.concerts.length,
+		addedConcerts: scrapeResult.value.added,
+		discoveredLinks: scrapeResult.value.discoveredLinks,
+	});
 };
 
 const attendedConcerts = (): Promise<
@@ -480,6 +534,7 @@ const attendedConcerts = (): Promise<
 
 const setlistfm = {
 	attendedConcerts,
+	refreshConcertsFromSetlistProfile,
 };
 
 export { setlistfm, SetlistFmDataError };

--- a/worker.ts
+++ b/worker.ts
@@ -16,6 +16,11 @@ import type {
 } from "./workflows/refresh-lastfm";
 import { RefreshLastFmWorkflow } from "./workflows/refresh-lastfm";
 import type {
+	RefreshWorkflowParams as SetlistFmRefreshParams,
+	RefreshSetlistFmWorkflowEnv,
+} from "./workflows/refresh-setlistfm";
+import { RefreshSetlistFmWorkflow } from "./workflows/refresh-setlistfm";
+import type {
 	StaleMonitorParams,
 	StaleMonitorWorkflowEnv,
 } from "./workflows/stale-data-monitor";
@@ -25,7 +30,8 @@ import { applyBaseRuntimeEnv } from "./workflows/shared";
 type WorkerEnv = StaleMonitorWorkflowEnv &
 	RefreshGarage61WorkflowEnv &
 	RefreshGoodreadsWorkflowEnv &
-	RefreshLastFmWorkflowEnv & {
+	RefreshLastFmWorkflowEnv &
+	RefreshSetlistFmWorkflowEnv & {
 		GARAGE61_REFRESH_WORKFLOW?: {
 			create: (options?: {
 				id?: string;
@@ -44,6 +50,12 @@ type WorkerEnv = StaleMonitorWorkflowEnv &
 				params?: LastFmRefreshParams;
 			}) => Promise<unknown>;
 		};
+		SETLISTFM_REFRESH_WORKFLOW?: {
+			create: (options?: {
+				id?: string;
+				params?: SetlistFmRefreshParams;
+			}) => Promise<unknown>;
+		};
 		STALE_MONITOR_WORKFLOW?: {
 			create: (options?: {
 				id?: string;
@@ -56,6 +68,7 @@ export {
 	RefreshGarage61Workflow,
 	RefreshGoodreadsWorkflow,
 	RefreshLastFmWorkflow,
+	RefreshSetlistFmWorkflow,
 	StaleDataMonitorWorkflow,
 };
 
@@ -133,6 +146,7 @@ export default {
 		triggerRefreshWorkflow(ctx, env.GARAGE61_REFRESH_WORKFLOW, "GARAGE61_REFRESH_WORKFLOW", "refresh-garage61", triggeredAt);
 		triggerRefreshWorkflow(ctx, env.GOODREADS_REFRESH_WORKFLOW, "GOODREADS_REFRESH_WORKFLOW", "refresh-goodreads", triggeredAt);
 		triggerRefreshWorkflow(ctx, env.LASTFM_REFRESH_WORKFLOW, "LASTFM_REFRESH_WORKFLOW", "refresh-lastfm", triggeredAt);
+		triggerRefreshWorkflow(ctx, env.SETLISTFM_REFRESH_WORKFLOW, "SETLISTFM_REFRESH_WORKFLOW", "refresh-setlistfm", triggeredAt);
 
 		if (minute !== 0) return;
 		if (!env.STALE_MONITOR_WORKFLOW) {

--- a/worker.ts
+++ b/worker.ts
@@ -146,7 +146,15 @@ export default {
 		triggerRefreshWorkflow(ctx, env.GARAGE61_REFRESH_WORKFLOW, "GARAGE61_REFRESH_WORKFLOW", "refresh-garage61", triggeredAt);
 		triggerRefreshWorkflow(ctx, env.GOODREADS_REFRESH_WORKFLOW, "GOODREADS_REFRESH_WORKFLOW", "refresh-goodreads", triggeredAt);
 		triggerRefreshWorkflow(ctx, env.LASTFM_REFRESH_WORKFLOW, "LASTFM_REFRESH_WORKFLOW", "refresh-lastfm", triggeredAt);
-		triggerRefreshWorkflow(ctx, env.SETLISTFM_REFRESH_WORKFLOW, "SETLISTFM_REFRESH_WORKFLOW", "refresh-setlistfm", triggeredAt);
+		if (scheduledAt.getUTCHours() === 0 && minute === 0) {
+			triggerRefreshWorkflow(
+				ctx,
+				env.SETLISTFM_REFRESH_WORKFLOW,
+				"SETLISTFM_REFRESH_WORKFLOW",
+				"refresh-setlistfm",
+				triggeredAt,
+			);
+		}
 
 		if (minute !== 0) return;
 		if (!env.STALE_MONITOR_WORKFLOW) {

--- a/workflows/refresh-setlistfm.ts
+++ b/workflows/refresh-setlistfm.ts
@@ -1,0 +1,37 @@
+import { setlistfm } from "@/lib/setlistfm";
+
+import { makeRefreshWorkflow, type RefreshWorkflowParams } from "./shared";
+
+export type { RefreshWorkflowParams };
+
+export type RefreshSetlistFmWorkflowEnv = {
+	APP_STORE?: KVNamespace;
+	KV_CACHE_VERSION?: string;
+	SETLIST_FM_USER?: string;
+};
+
+export const RefreshSetlistFmWorkflow = makeRefreshWorkflow<RefreshSetlistFmWorkflowEnv>({
+	stepName: "refresh-setlistfm",
+	refresh: () =>
+		setlistfm.refreshConcertsFromSetlistProfile({
+			...(process.env.SETLIST_FM_USER
+				? { user: process.env.SETLIST_FM_USER }
+				: {}),
+		}) as Promise<import("better-result").Result<unknown, unknown>>,
+	applyEnv: (env) => {
+		process.env.SETLIST_FM_USER =
+			env.SETLIST_FM_USER ?? process.env.SETLIST_FM_USER ?? "kpmdev";
+	},
+	buildDetails: (value) => {
+		const data = value as {
+			totalConcerts: number;
+			addedConcerts: number;
+			discoveredLinks: number;
+		};
+		return {
+			totalConcerts: data.totalConcerts,
+			addedConcerts: data.addedConcerts,
+			discoveredLinks: data.discoveredLinks,
+		};
+	},
+});

--- a/wrangler.json
+++ b/wrangler.json
@@ -40,6 +40,11 @@
 			"class_name": "RefreshLastFmWorkflow"
 		},
 		{
+			"binding": "SETLISTFM_REFRESH_WORKFLOW",
+			"name": "refresh-setlistfm",
+			"class_name": "RefreshSetlistFmWorkflow"
+		},
+		{
 			"binding": "STALE_MONITOR_WORKFLOW",
 			"name": "stale-data-monitor",
 			"class_name": "StaleDataMonitorWorkflow"


### PR DESCRIPTION
## Summary
- add runtime-safe Setlist.fm scraper module adapted from existing script logic
- add `refresh-setlistfm` Cloudflare Workflow to scrape profile links and upsert raw concerts into KV
- make Setlist data loading KV-first with fallback to bundled `content/concerts.json`
- refresh aggregated `ConcertsData` cache in KV after raw scrape updates
- wire workflow binding into worker + wrangler config

## Why
This keeps branch/production runtime data in KV and allows incremental updates without committing `content/concerts.json` for each new show.

## Validation
- `npm run typecheck`
- `npm test`

## Notes
- Default profile user is `kpmdev`; can be overridden with `SETLIST_FM_USER` env var.
- Existing file data remains a safe fallback if KV is empty/invalid.
